### PR TITLE
Improve error message for assertions of length 0

### DIFF
--- a/R/assert-that.r
+++ b/R/assert-that.r
@@ -87,6 +87,8 @@ check_result <- function(x) {
     stop("assert_that: assertion must return a logical value", call. = FALSE)
   if (any(is.na(x)))
     stop("assert_that: missing values present in assertion", call. = FALSE)
+  if (length(x) == 0)
+    stop("assert_that: assertion has length 0", call. = FALSE)
   if (length(x) > 1) {
     stop("assert_that: assertion has length greater than 1", call. = FALSE)
   }

--- a/R/assert-that.r
+++ b/R/assert-that.r
@@ -87,10 +87,8 @@ check_result <- function(x) {
     stop("assert_that: assertion must return a logical value", call. = FALSE)
   if (any(is.na(x)))
     stop("assert_that: missing values present in assertion", call. = FALSE)
-  if (length(x) == 0)
-    stop("assert_that: assertion has length 0", call. = FALSE)
-  if (length(x) > 1) {
-    stop("assert_that: assertion has length greater than 1", call. = FALSE)
+  if (length(x) != 1) {
+    stop("assert_that: length of assertion is not 1", call. = FALSE)
   }
 
   TRUE


### PR DESCRIPTION
This improves the error message when the assertion evaluates to a vector of length 0. Currently, `assertthat` throws

```R
assert_that(logical())
# Error in if (!res) { : argument is of length zero
```