### PR TITLE
Handle NaN and Inf in is.integerish()

### DIFF
--- a/R/assertions.r
+++ b/R/assertions.r
@@ -2,7 +2,7 @@
 NULL
 
 is.integerish <- function(x) {
-  is.integer(x) || (is.numeric(x) && all(x == as.integer(x)))
+  is.integer(x) || (!is.nan(x) && !is.infinite(x) && is.numeric(x) && all(x == as.integer(x)))
 }
 
 # is.positive.integer


### PR DESCRIPTION
Current behavior:

``` r
assertthat:::is.integerish(NaN)
# [1] NA
assertthat:::is.integerish(Inf)
# [1] NA
# Warning message:
# In assertthat:::is.integerish(Inf) :
#   NAs introduced by coercion to integer range
```

With change:

``` r
is.integerish(NaN)
# [1] FALSE
is.integerish(Inf)
# [1] FALSE
```
