### PR TITLE
Fix manual page: flag = logical, not numeric/integer

### DIFF
--- a/R/assertions-scalar.R
+++ b/R/assertions-scalar.R
@@ -58,7 +58,7 @@ on_failure(is.number) <- function(call, env) {
 #' @rdname scalar
 #' @export
 #' @examples
-#' # flag = scalar numeric/integer vector
+#' # flag = scalar logical vector
 #' see_if(is.flag(1:3))
 #' see_if(is.flag("a"))
 #' see_if(is.flag(c(FALSE, FALSE, TRUE)))

--- a/man/scalar.Rd
+++ b/man/scalar.Rd
@@ -36,7 +36,7 @@ see_if(is.string("x"))
 # number = scalar numeric/integer vector
 see_if(is.number(1:3))
 see_if(is.number(1.5))
-# flag = scalar numeric/integer vector
+# flag = scalar logical vector
 see_if(is.flag(1:3))
 see_if(is.flag("a"))
 see_if(is.flag(c(FALSE, FALSE, TRUE)))


### PR DESCRIPTION
Fix a small mistake on one manual page.

On another note, is there a reason why `is.integerish()` is not exported?
