### PR TITLE
Fixed handling of long custom assertions

### DIFF
--- a/R/assert-that.r
+++ b/R/assert-that.r
@@ -111,10 +111,13 @@ get_message <- function(res, call, env = parent.frame()) {
 
 # The default failure message works in the same way as stopifnot, so you can
 # continue to use any function that returns a logical value: you just won't
-# get a friendly error message
+# get a friendly error message.
+# The code below says you get the first 60 characters plus a ...
 fail_default <- function(call, env) {
   call_string <- deparse(call, width.cutoff = 60L)
-  if (length(call_string) > 1L) ch <- paste0(call_string[1L], "...")
+  if (length(call_string) > 1L) {
+      call_string <- paste0(call_string[1L], "...")
+  }
 
   paste0(call_string, " is not TRUE")
 }

--- a/tests/testthat/test-assert-that.R
+++ b/tests/testthat/test-assert-that.R
@@ -1,0 +1,8 @@
+context("assert_that")
+
+test_that("assert_that handles long false assertions gracefully", {
+    expect_error(
+        assert_that(isTRUE(10 + sqrt(25) + sum(1:10) + sqrt(25) + sum(11:20) + sqrt(25) + sum(21:30) + sqrt(25) + sum(31:40) + sqrt(25) + sum(41:50))),
+        "^isTRUE\\(.* [.]{3} is not TRUE$"
+    )
+})


### PR DESCRIPTION
This PR addresses #43 . You can use the code reported there to reproduce.

Given a super long assertion like this:

```
assert_that(4 %>% sqrt %>% multiply_by(10) %>% divide_by(5) %>% add(13) %>% subtract(20) %>% equals(0))
```

`see_if` returns multiple lines of the call and results in this error:

```
Error in stop(assertError(attr(res, "msg"))) : bad error message
```

As of the changes on this PR, the behavior will be closer to what is expected:

```
> assert_that(4 %>% sqrt %>% multiply_by(10) %>% divide_by(5) %>% add(13) %>% subtract(20) %>% equals(0))
Error: `%>%`(lhs = 4 %>% sqrt %>% multiply_by(10) %>% divide_by(5) %>% ... is not TRUE
```

Thank you for considering this PR.