### PR TITLE
Fix inconsistency in has_name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # assertthat 0.2.0.9000
+ 
+* `has_name()` now rejects attempts to check multiple names in a single function call (@jameslamb, #46)
 
 # assertthat 0.2.0
 

--- a/R/assertions.r
+++ b/R/assertions.r
@@ -40,7 +40,10 @@ on_failure(has_attr) <- function(call, env) {
 
 #' @export
 #' @rdname has_attr
-has_name <- function(x, which) which %in% names(x)
+has_name <- function(x, which){
+    assert_that(is.scalar(which), msg = "multiple values passed to has_name")
+    which %in% names(x)
+}
 on_failure(has_name) <- function(call, env) {
   paste0(deparse(call$x), " does not have name ", eval(call$which, env))
 }

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -49,6 +49,7 @@ test_that("has_name works correctly", {
   expect_true(has_name(x, letters[2]))
   expect_false(has_name(x, "something else"))
   expect_false(has_name(x, NA))
+  expect_error(has_name(x, c("a", "b")), "multiple values passed to has_name")
 })
 
 test_that("noNA works correctly", {


### PR DESCRIPTION
This PR addresses an inconsistency in how `has_name` works, raised in #9 . Other assertions in the package only return a single value, but right now `has_name` can return multiple values.

```
t <- data.frame(a = 1:10, b = rep(TRUE, 10))
assert_that(has_name(t, c("a", "b")))

Error: assert_that: length of assertion is not 1
```

The above occurs because `has_name(t, c("a", "b"))` returns a length-2 vector of `TRUE`s.

This PR changes the behavior of `has_name` to break early and reject attempts to pass multiple names to `has_name`.

I would also propose that we add a `has_names` in a separate PR, since I can see that being a common requirement ("does this thing have all of these 10 names?"). I can say, anecdotally, that I find myself using `expect_named` in my `testthat` stuff all the time.