### PR TITLE
Add better handling for large numbers in is.integerish

### DIFF
--- a/R/assertions.r
+++ b/R/assertions.r
@@ -2,7 +2,10 @@
 NULL
 
 is.integerish <- function(x) {
-  is.integer(x) || (is.numeric(x) && all(x == as.integer(x)))
+  
+  # using trunc() to deal with very large numbers (including Inf)
+  res <- is.integer(x) || (is.numeric(x) && all(x == trunc(x)))
+  res
 }
 
 # is.positive.integer

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -10,6 +10,16 @@ test_that("is.integerish works correctly", {
   expect_false(is.integerish(1L + .Machine$double.eps))
   expect_false(is.integerish(1L - .Machine$double.neg.eps))
   
+  # numbers larger than base::.Machine$integer.max shouldn't trip this up
+  expect_true(is.integerish(Inf))
+  expect_true(is.integerish(-Inf))
+  
+  expect_true(is.integerish(1e10))
+  expect_true(is.integerish(-1e10))
+  
+  expect_false(is.integerish(1e10 + 0.0002))
+  expect_false(is.integerish(1e10 - 0.0002))
+
   expect_false(is.integerish(NA))
   expect_false(is.integerish(NULL))
 })

--- a/tests/testthat/test-scalar.R
+++ b/tests/testthat/test-scalar.R
@@ -11,6 +11,8 @@ test_that("is.scalar works correctly", {
   expect_false(is.scalar(c(TRUE, FALSE)))
   expect_false(is.scalar(NULL))
   expect_true(is.scalar(NA))
+  expect_true(is.scalar(Inf))
+  expect_true(is.scalar(-Inf))
 })
 
 test_that("is.string works correctly", {
@@ -20,6 +22,8 @@ test_that("is.string works correctly", {
   expect_false(is.string(TRUE))
   expect_false(is.string(NULL))
   expect_false(is.string(NA))
+  expect_false(is.string(Inf))
+  expect_false(is.string(-Inf))
 })
 
 test_that("is.number works correctly", {
@@ -31,6 +35,8 @@ test_that("is.number works correctly", {
   expect_false(is.number(TRUE))
   expect_false(is.number(NULL))
   expect_false(is.number(NA))
+  expect_true(is.number(Inf))
+  expect_true(is.number(-Inf))
 })
 
 test_that("is.flag works correctly", {
@@ -41,6 +47,8 @@ test_that("is.flag works correctly", {
   expect_false(is.flag(c(TRUE, FALSE)))
   expect_false(is.flag(NULL))
   expect_equal(is.flag(NA), is.logical(NA)) # not obvious
+  expect_false(is.flag(Inf))
+  expect_false(is.flag(-Inf))
 })
 
 test_that("is.count works correctly", {
@@ -52,4 +60,8 @@ test_that("is.count works correctly", {
   expect_false(is.count(TRUE))
   expect_false(is.count(NULL))
   expect_false(is.count(NA))
+  expect_true(is.count(Inf))
+  expect_false(is.count(-Inf))
+  expect_false(is.count(1e10 + 0.0001))
+  expect_false(is.count(1e10 - 0.1))
 })


### PR DESCRIPTION
This PR addresses concerns raised in #42 and #44 . Basically, `is.integerish` encounters NAs when you try to apply it over values that are larger than `base::.Machine$integer.max`. In this PR, I just added explicit handling for that condition to throw a more informative error message.