### PR TITLE
Handle NA_real_, NaN and NA_integer_ in is.count()

### DIFF
--- a/R/assertions-scalar.R
+++ b/R/assertions-scalar.R
@@ -84,7 +84,8 @@ is.count <- function(x) {
   if (length(x) != 1) return(FALSE)
   if (!is.integerish(x)) return(FALSE)
   
-  x > 0
+  # is.na() to handle NA_integer_
+  x > 0 && !is.na(x)
 }
 on_failure(is.count) <- function(call, env) {
   paste0(deparse(call$x), " is not a count (a single positive integer)")

--- a/R/assertions.r
+++ b/R/assertions.r
@@ -2,9 +2,8 @@
 NULL
 
 is.integerish <- function(x) {
-  
-  # using trunc() to deal with very large numbers (including Inf)
-  res <- is.integer(x) || (is.numeric(x) && all(x == trunc(x)))
+  # using trunc() to deal with very large numbers (including Inf) and is.na() to deal with NaN and NA_real_
+  res <- is.integer(x) || (is.numeric(x) && all(x == trunc(x)) && !is.na(x))
   res
 }
 


### PR DESCRIPTION
is.count() returns FALSE for NA_real_, NaN and NA_integer_. is.integerish() returns FALSE (instead of NA) for NA_real_ and NaN.