### PR TITLE
Added 0.2.0.9000 changes to NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,20 +1,20 @@
 # assertthat 0.2.0.9000
 
+* `assert_that()` no longer throws a fatal error on very long custom expressions (@jameslamb, #45)
+* 
 * `is.count()` returns `FALSE` for `NA_real_`, `NaN` and `NA_integer_`. `is.integerish()` returns `FALSE` for `NA_real_` and `NaN` (@drkarthi, #54)
 
 * `is.count()`, `is.flag()`, `is.number()`, and `is.scalar()` now have well-defined behavior for `Inf`, `-Inf`, and finite but large numbers (@jameslamb, #47)
 
 * `has_name()` now rejects attempts to check multiple names in a single function call (@jameslamb, #46)
 
-* `assert_that()` no longer throws a fatal error on very long custom expressions (@jameslamb, #45)
-
 # assertthat 0.2.0
 
 * `assert_that()`, `see_if()`, and `validate_that()` get a `msg` argument 
   that allows you to provide a custom message (@krlmlr, #6)
-  
-* New tests cover most assertions (@bpbond, #18, #20)
 
-* `is.named()` returns `TRUE` if an element has `NA` name (#20)
+* `is.named()` returns `TRUE` if an element has `NA` name (#20) 
+
+* New tests cover most assertions (@bpbond, #18, #20)
 
 * Better error message if assertion is length 0 (@paulstaab, #22)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 # assertthat 0.2.0.9000
- 
+
+* `is.count()` returns `FALSE` for `NA_real_`, `NaN` and `NA_integer_`. `is.integerish()` returns `FALSE` for `NA_real_` and `NaN` (@drkarthi, #54)
+
+* `is.count()`, `is.flag()`, `is.number()`, and `is.scalar()` now have well-defined behavior for `Inf`, `-Inf`, and finite but large numbers (@jameslamb, #47)
+
 * `has_name()` now rejects attempts to check multiple names in a single function call (@jameslamb, #46)
+
+* `assert_that()` no longer throws a fatal error on very long custom expressions (@jameslamb, #45)
 
 # assertthat 0.2.0
 
@@ -12,5 +18,3 @@
 * `is.named()` returns `TRUE` if an element has `NA` name (#20)
 
 * Better error message if assertion is length 0 (@paulstaab, #22)
-
-* `is.count()` returns `FALSE` for `NA_real_`, `NaN` and `NA_integer_`. `is.integerish()` returns `FALSE` for `NA_real_` and `NaN` (@drkarthi, #54)


### PR DESCRIPTION
Per conversation on #57 , in this PR I proposed updating `NEWS.md` to accurately reflect fixes that have gone in since 0.2.0 was released in 2017.

@hadley in addition to moving the note on #54 up to the current release (it was inaccurately placed under 0.2.0), I also added documentation for #45 and #47. I apologize for not updating NEWS on those PRs.