### PR TITLE
has_name now always returns a sginel logical value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,12 @@
 # assertthat 0.2.0.9000
 
 * `assert_that()` no longer throws a fatal error on very long custom expressions (@jameslamb, #45)
-* 
+
 * `is.count()` returns `FALSE` for `NA_real_`, `NaN` and `NA_integer_`. `is.integerish()` returns `FALSE` for `NA_real_` and `NaN` (@drkarthi, #54)
 
 * `is.count()`, `is.flag()`, `is.number()`, and `is.scalar()` now have well-defined behavior for `Inf`, `-Inf`, and finite but large numbers (@jameslamb, #47)
 
-* `has_name()` now rejects attempts to check multiple names in a single function call (@jameslamb, #46)
+* `has_name()` now always returns a single `TRUE`/`FALSE`, even if you use it to check multiple names (@jameslamb, #60)
 
 # assertthat 0.2.0
 

--- a/R/assertions.r
+++ b/R/assertions.r
@@ -32,6 +32,7 @@ on_failure(is.named) <- function(call, env) {
 #'
 #' y <- list(a = 1, b = 2)
 #' see_if(y %has_name% "c")
+#' see_if(y %has_name% c("a", "g", "f"))
 has_attr <- function(x, which) !is.null(attr(x, which, exact = TRUE))
 on_failure(has_attr) <- function(call, env) {
   paste0(deparse(call$x), " does not have attribute ", eval(call$which, env))
@@ -43,11 +44,11 @@ on_failure(has_attr) <- function(call, env) {
 #' @export
 #' @rdname has_attr
 has_name <- function(x, which){
-    assert_that(is.scalar(which), msg = "multiple values passed to has_name")
-    which %in% names(x)
+    all(which %in% names(x))
 }
 on_failure(has_name) <- function(call, env) {
-  paste0(deparse(call$x), " does not have name ", eval(call$which, env))
+    out_names <- paste0("'", paste0(eval(call$which, env), collapse = "', '"), "'")
+    paste0(deparse(call$x), " does not have all of these name(s): ", out_names)
 }
 #' @export
 #' @rdname has_attr
@@ -141,7 +142,7 @@ on_failure(is.date) <- function(call, env) {
 #' see_if(mean %has_args% "y")
 has_args <- function(f, args, exact = FALSE) {
   assert_that(is.function(f))
-  
+
   if (exact) {
     identical(args, names(formals(f)))
   } else {

--- a/tests/testthat/test-assert-that.R
+++ b/tests/testthat/test-assert-that.R
@@ -6,3 +6,11 @@ test_that("assert_that handles long false assertions gracefully", {
         "^isTRUE\\(.* [.]{3} is not TRUE$"
     )
 })
+
+test_that("assert_that handles has_name failures with multiple missing names", {
+    x <- list(a = TRUE, b = "hello")
+    expect_error(
+        assert_that(has_name(x, c("a", "f", "g"))),
+        regexp = "x does not have all of these name"
+    )
+})

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -5,18 +5,18 @@ test_that("is.integerish works correctly", {
   expect_true(is.integerish(c(1L, 2L, 3L)))
   expect_true(is.integerish(c(1L, NA, 3L)))
   expect_false(is.integerish(c(1L, 2.1, 3L)))
-  
+
   # base::.Machine holds info on machine numerical precision
   expect_false(is.integerish(1L + .Machine$double.eps))
   expect_false(is.integerish(1L - .Machine$double.neg.eps))
-  
+
   # numbers larger than base::.Machine$integer.max shouldn't trip this up
   expect_true(is.integerish(Inf))
   expect_true(is.integerish(-Inf))
-  
+
   expect_true(is.integerish(1e10))
   expect_true(is.integerish(-1e10))
-  
+
   expect_false(is.integerish(1e10 + 0.0002))
   expect_false(is.integerish(1e10 - 0.0002))
 
@@ -32,7 +32,7 @@ test_that("is.named works correctly", {
   expect_false(is.named(x))
   names(x) <- letters[1:3]
   expect_true(is.named(x))
-  
+
   # Malformed or weird names
   names(x)[2] <- ""
   expect_false(is.named(x))
@@ -40,7 +40,7 @@ test_that("is.named works correctly", {
   expect_false(is.named(x))
   names(x) <- NULL
   expect_false(is.named(x))
-  
+
   expect_false(is.named(NA))
   expect_false(is.named(NULL))
 })
@@ -61,7 +61,9 @@ test_that("has_name works correctly", {
   expect_true(has_name(x, letters[2]))
   expect_false(has_name(x, "something else"))
   expect_false(has_name(x, NA))
-  expect_error(has_name(x, c("a", "b")), "multiple values passed to has_name")
+  expect_true(has_name(x, c("a", "b")))
+  expect_true(has_name(x, c("a", "b", "c")))
+  expect_false(has_name(x, c("a", "d")))
 })
 
 test_that("noNA works correctly", {
@@ -79,7 +81,7 @@ test_that("are_equal works correctly", {
   expect_true(are_equal(x, 2))
   expect_true(are_equal('a', 'a'))
   expect_false(are_equal('a', 'b'))
-  
+
   expect_true(are_equal(NA, NA))
   expect_true(are_equal(NULL, NULL))
 })
@@ -88,8 +90,8 @@ test_that("is.error works correctly", {
   x <- try(stop("!!"), silent=TRUE)
   expect_true(is.error(x))
   expect_false(is.error(1))
-  
-  expect_false(is.error(NA))  
+
+  expect_false(is.error(NA))
   expect_false(is.error(NULL))
 })
 
@@ -97,8 +99,8 @@ test_that("is.time works correctly", {
   expect_true(is.time(Sys.time()))
   expect_false(is.time(Sys.Date()))
   expect_false(is.time(1))
-  
-  expect_false(is.time(NA))  
+
+  expect_false(is.time(NA))
   expect_false(is.time(NULL))
 })
 
@@ -106,8 +108,8 @@ test_that("is.date works correctly", {
   expect_false(is.date(Sys.time()))
   expect_true(is.date(Sys.Date()))
   expect_false(is.date(1))
-  
-  expect_false(is.date(NA))  
+
+  expect_false(is.date(NA))
   expect_false(is.date(NULL))
 })
 
@@ -115,15 +117,15 @@ test_that("has_args works correctly", {
   expect_error(1 %has_args% "x")
   expect_true(mean %has_args% "x")
   expect_false(mean %has_args% "y")
-  
+
   expect_error(NA %has_args% "x")
   expect_error(NULL %has_args% "x")
-  
+
   # should pass with exact = FALSE if you don't have all the args or you the order is different
   expect_true(has_args(rnorm, "n"))
   expect_true(has_args(rnorm, c("n", "mean")))
   expect_true(has_args(rnorm, c("mean", "sd", "n")))
-  
+
   # should pass with exact = TRUE if you don't have all the args or you the order is different
   expect_false(has_args(rnorm, "n", exact = TRUE))
   expect_false(has_args(rnorm, c("n", "mean"), exact = TRUE))


### PR DESCRIPTION
Per discussion in #59 . In #46 I made `has_name()` throw an error if you tried to check multiple names in one call, e.g.

```
x <- list(a = TRUE, b = "hello")
has_name(x, c("a", "b"))
```

Four packages on CRAN have code (covered by tests) that uses `has_name()` with multiple names, and all of them do this:

```
all(has_name(x, c("a", "b"))
```

Instead of breaking their code, I think the spirit of #46 (all assertions return exactly one `TRUE`/`FALSE`) can still be accomplished by using an `all()` inside `has_name()`! That is what I've proposed in this PR.