### PR TITLE
Fix custom error messages for nested functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # assertthat (development version)
 
+* nested functions with custom assertion messages give an error at the correct
+  position (@banfai, #70)
+
 # assertthat 0.2.1
 
 * `assert_that()` no longer throws a fatal error on very long custom 

--- a/R/assert-that.r
+++ b/R/assert-that.r
@@ -73,7 +73,7 @@ see_if <- function(..., env = parent.frame(), msg = NULL) {
 
     # Failed, so figure out message to produce
     if (!res) {
-      if (is.null(msg))
+      if (is.null(msg) || has_attr(res, "msg")) 
         msg <- get_message(res, assertion, env)
       return(structure(FALSE, msg = msg))
     }

--- a/tests/testthat/test-assert-that.R
+++ b/tests/testthat/test-assert-that.R
@@ -14,3 +14,10 @@ test_that("assert_that handles has_name failures with multiple missing names", {
         regexp = "x does not have all of these name"
     )
 })
+
+test_that("assert_that correctly handles nested assertions", 
+    expect_error(
+        assert_that(assert_that(FALSE, msg = "inner"), msg = "outer"),
+        regexp = "inner"
+    )
+)


### PR DESCRIPTION
Fixes #70 

It's not a problem with lazy evaluation or promises, it's caused by the incorrect propagation of `msg`.
If one of the assertions is already coming from `assert_that` then it has an `msg` attribute, this has to be propagated further.

Test is added to check this:
`assert_that(assert_that(FALSE, msg = "inner"), msg = "outer")` should fail with "inner".

Reprex from #70 after this PR:
``` r
inner_f <- function(argument) {
  assertthat::assert_that(argument > 0, msg = "inner_f")
  argument
}

outer_f <- function(argument) {
  assertthat::assert_that(argument > 0, msg = "outer_f")
}

outer_f(inner_f(0))
#> Error: inner_f
```

<sup>Created on 2021-11-04 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

The added test and all other tests pass correctly.
