### PR TITLE
Replace 'or' with 'and' to fix #64

### DIFF
--- a/R/base-logical.r
+++ b/R/base-logical.r
@@ -18,7 +18,7 @@ base_fs$"||" <- function(call, env) {
   rhs <- eval(call[[3]], env)
   r_msg <- get_message(rhs, call[[3]], env)
 
-  paste0(l_msg, " or ", r_msg)
+  paste0(l_msg, " and ", r_msg)
 }
 
 base_fs$any <- function(call, env) {


### PR DESCRIPTION
If an "or" assertion fails, both lhs *and* rhs failed.